### PR TITLE
Fix spago install name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Classes extracted from https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/boo
 ## Installation
 
 ```
-spago install purescript-halogen-bootstrap5
+spago install halogen-bootstrap5
 ```
 
 ## Documentation


### PR DESCRIPTION
Hi @tonicebrian! Just wanted to let you know that Spago uses the package name registered with the registry (ie. `halogen-boostrap5`), not the repo name (`purescript-halogen-bootstrap5`). Fixed that in the README.